### PR TITLE
Typo fix in the code

### DIFF
--- a/packages/transporter/src/base.ts
+++ b/packages/transporter/src/base.ts
@@ -24,5 +24,5 @@ export interface Transporter<T> {
   ackRecord(id: number): Promise<void>;
   sendStop(): Promise<void>;
   sendRemoteControl(payload: unknown): Promise<void>;
-  on(event: TransporterEvents, hanlder: TransporterEventHandler): void;
+  on(event: TransporterEvents, handler: TransporterEventHandler): void;
 }


### PR DESCRIPTION
TransporterEventsHandler argument field has a typo, which is fixed in this PR. 